### PR TITLE
This pull request is to address the issue in json

### DIFF
--- a/jobs.json
+++ b/jobs.json
@@ -162,7 +162,7 @@
     ]
   },
     {
-    "jobId": "2",
+    "jobId": "7",
     "title": "Marketing Officer",
     "type": "Full-Time",
     "experience": "2-3 Yrs",
@@ -189,7 +189,7 @@
     ]
   },
   {
-    "jobId": "3",
+    "jobId": "8",
     "title": "PR and Outreach Intern",
     "type": "Full-Time",
     "experience": "0-1 Yrs",
@@ -216,7 +216,7 @@
     ]
   },
   {
-    "jobId": "4",
+    "jobId": "9",
     "title": "General Applications",
     "type": "Full-Time/Part-Time",
     "experience": "0-3 Yrs",


### PR DESCRIPTION
This pull request addresses an issue with job IDs where multiple jobs share the same `jobId` parameter. 
As a result, accessing a job with `jobId` 3 inadvertently redirects to the first job assigned with that ID, causing confusion and incorrect data retrieval.

To resolve this, I have implemented changes to ensure that job retrieval is unique and correctly associated with its intended `jobId`. This improvement will enhance the integrity of job access and user experience.